### PR TITLE
fix ping négatif

### DIFF
--- a/src/plugins/init/commands/ping.js
+++ b/src/plugins/init/commands/ping.js
@@ -28,7 +28,7 @@ async function execute(interaction) {
 
     await interaction.reply({
         content: `🏓 **PING**
-		La latence du bot est de ${interaction.createdTimestamp - Date.now()}ms.
+		La latence du bot est de ${Date.now() - interaction.createdTimestamp}ms.
 		Latence API Discord : ${Math.round(interaction.client.ws.ping)}ms`,
         ephemeral: false,
     });


### PR DESCRIPTION
Le commande ping renvoyait une valeur négative. Cela avait déjà été corrigé auparavant (j'ai regarder dans l'historique des commits) mais le patch s'est perdu en route apparemment